### PR TITLE
Add timeout option

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -22,7 +22,7 @@ var Engine = exports.Engine = function Engine(options) {
   global.wait = require('./keywords/wait');
   global.parallelize = require('./keywords/parallelize');
   global.feature = require('./keywords/feature')(this);
-  
+
   environment.load(utils.findEnvFile(options.path));
   environment.config.console = options.console;
   Reporter = require('mocha/lib/reporters/' + (options.reporter || environment.config.reporter || 'spec'));
@@ -37,9 +37,9 @@ Engine.prototype.run = function() {
     this.rootSuite.emit('require', require(this.file), this.file);
     this.rootSuite.emit('post-require', global, this.file);
   }
-  
+
   this.featureManager.loadFeatures(this.options.feature);
-  
+
   var runner = new mocha.Runner(this.rootSuite);
   runner.on('test', function(test) {
     // a hack to show the test body as a stack trace on errors
@@ -47,7 +47,7 @@ Engine.prototype.run = function() {
     global.feature.currentTest = test;
   });
   var reporter = new Reporter(runner);
-  
+
   runner.run(process.exit);
 };
 

--- a/lib/webspecter.js
+++ b/lib/webspecter.js
@@ -13,7 +13,7 @@ program
 .usage('[options] test_dir')
 .option('-f, --feature <title>', 'title of the feature to be tested', null)
 .option('-c, --console', 'forward JavaScript console to stderr')
-.option('-t, --timeout', 'set timeout of individual tests')
+.option('-t, --timeout <n>', 'set timeout of individual tests', parseInt)
 .option('-R, --reporter <name>', 'specify the reporter to use', null)
 .option('--reporters', 'display available reporters')
 .parse(process.argv);


### PR DESCRIPTION
We were using this to run integration tests and wanted to up the timeout. We added an option that passes timeout directly to mocha or defaults to 10000ms.
