### PR TITLE
basic solution for set global vars during webspecter starting

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -22,6 +22,20 @@ var Engine = exports.Engine = function Engine(options) {
   global.wait = require('./keywords/wait');
   global.parallelize = require('./keywords/parallelize');
   global.feature = require('./keywords/feature')(this);
+  
+//   This code add settings defined during running webspecter to global.settings
+  global.settings = {};
+  if (options.globals){
+  	var global_settings_list = options.globals.split(';;'),
+  		g_counter, key_val; 
+  	for (g_counter in global_settings_list){
+  		key_val = global_settings_list[g_counter].split('=');
+  		if (key_val.length === 2){
+  			global.settings[key_val[0]] = key_val[1]; 	
+  		}
+  	} 
+  }
+// end of setup settings	
 
   environment.load(utils.findEnvFile(options.path));
   environment.config.console = options.console;

--- a/lib/webspecter.js
+++ b/lib/webspecter.js
@@ -16,6 +16,7 @@ program
 .option('-t, --timeout <n>', 'set timeout of individual tests', parseInt)
 .option('-R, --reporter <name>', 'specify the reporter to use', null)
 .option('--reporters', 'display available reporters')
+.option('--globals <vars_list>. For example --globals location=http://localhost:8000\;\;test=true', 'list of global vars')
 .parse(process.argv);
 
 if (program.reporters) {


### PR DESCRIPTION
This is basic update that allow developers set some basic variables during webspecter run
